### PR TITLE
Smoothing Splines in estimation

### DIFF
--- a/config.json
+++ b/config.json
@@ -56,7 +56,8 @@
         "outlier_scale_factor": 0.05
     },
     "Estimate": {
-        "mininum_total_trajectory_points": 30
+        "mininum_total_trajectory_points": 30,
+        "smoothing_factor": 1.0
     },
     "Solver": {
         "gas_data_path": "/path/to/some/gas.json",

--- a/docs/user_guide/config/estimate.md
+++ b/docs/user_guide/config/estimate.md
@@ -3,9 +3,10 @@
 The Estimate parameters control the estimation phase. The default estimate parameters given in `config.json` are:
 
 ```json
-"Estimate":
+"Estimate": 
 {
     "mininum_total_trajectory_points": 30,
+    "smoothing_factor": 1.0
 },
 ```
 
@@ -14,3 +15,7 @@ A break down of each parameter:
 ## minimum_total_trajectory_points
 
 Minimum number of points in a cluster to be considered a valid trajectory. Any clusters smaller will be ignored.
+
+## smoothing_factor
+
+This is the parameter which controls the "degree" of smoothing which is applied to the cluster in x, y, and charge as a function of z. Each of these coordinates is smoothed using smoothing splines from the scipy toolkit. Our `smoothing_factor` parameter is a re-exposure of scipy's `lam` parameter in the function `make_smoothing_splines` (see [the docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.make_smoothing_spline.html#scipy.interpolate.make_smoothing_spline) for more details). Note that we cannot use scipy's default estimation feature for the smoothing factor; th estimation of `lam` is extremely slow, as it is an optimization problem. `smoothing_factor` cannot be negative, and in general seems to be around 1.0 for most of the data. This parameter needs more testing across more datasets, so please let us know if you find anyting interesting!

--- a/docs/user_guide/config/extending.md
+++ b/docs/user_guide/config/extending.md
@@ -34,10 +34,10 @@ should look very similar to the Workspace section of our JSON
 },
 ```
 
-If you're not familiar with dataclasses, you can read up on them [here](https://docs.python.org/3/library/dataclasses.html). Essentially, this wrapper allows you to make simple data holding structures. We then store all of these parameter sets in a parent Config class. So the only trick is translating the JSON to Python, and thankfully the python standard library already does most of this for us. In the function `json_load_config_hook` we take the dictionary of parsed JSON data and place it into our structures. Check out the following snippet:
+If you're not familiar with dataclasses, you can read up on them [here](https://docs.python.org/3/library/dataclasses.html). Essentially, this wrapper allows you to make simple data holding structures. We then store all of these parameter sets in a parent Config class. So the only trick is translating the JSON to Python, and thankfully the python standard library already does most of this for us. In the function `deserialize_config` we take the dictionary of parsed JSON data and place it into our structures. Check out the following snippet:
 
 ```python
-def json_load_config_hook(json_data: dict[Any, Any]) -> Config:
+def deserialize_config(json_data: dict[Any, Any]) -> Config:
     config = Config()
     ws_params = json_data['Workspace']
     config.workspace.trace_data_path = ws_params['trace_data_path']
@@ -52,5 +52,5 @@ So extending the configuration is as simple as:
 
 1. Make a new set of configuration parameters in the JSON
 2. Add a new dataclass to config.py
-3. Add the new dataclass to the Config parent class
-4. Update the json_load_config_hook function
+3. Add the new dataclass to the `Config` parent class
+4. Update the `deserialize_config` function

--- a/docs/user_guide/phases/estimate.md
+++ b/docs/user_guide/phases/estimate.md
@@ -16,7 +16,9 @@ The estimation phase is probably the most hard-to-read part of the Spyral framew
 
 First, we do some bad trajectory rejection. Trajectories are rejected based on the number of points and their near-ness to the beam axis. If trajectories have too few points or too many points in the beam region, we reject them. These parameters are exposed in the [configuration](../config/estimate.md).
 
-Once we're confident we've idenfied a valid trajectory, its time to start estimating. First we try to see if the trajectory is going forward (towards the micromegas) or backward (toward the window) by calculating the average &rho; (distance to beam axis) at either end of the trajectory. Due to energy loss, the trajectories in-spiral, so the end with the smaller &rho; is the direction of travel, and the larger is the closest to the reaction vertex.
+Once we're confident we've idenfied a valid trajectory, we need to smooth the trajectory as a function of z. This is done using smoothing splines in the `Cluster` class. The degree of smoothing is controlled by the [configuration](../config/estimate.md). This operation collapses the cluster data to a set of piecewise polynomaials as a function of z. The reason we need this is to give better estimates of distance along the trajectory. The raw data is too noisy in position and charge to perform accurate line integrals.
+
+Now, its time to start estimating. First we try to see if the trajectory is going forward (towards the micromegas) or backward (toward the window) by calculating the average &rho; (distance to beam axis) at either end of the trajectory. Due to energy loss, the trajectories in-spiral, so the end with the smaller &rho; is the direction of travel, and the larger is the closest to the reaction vertex.
 
 We then fit a circle to the first arc of the trajectory. This is done by fitting the region from the start of the trajectory to the point of furthest distance in &rho;. That circle fit is used to estimate the radius of curvature. The circle fit is also used to extract the reaction vertex X and Y coordinates by extrapolating the fit circle to the closest approach to the beam axis. Finally, we also fit a small segment of the beginning of the trajectory to with a line in &rho; vs. z. Using the extrapolated vertex X and Y, we can then use the linear fit to estimate a vertex Z. The polar angle is extracted from the slope of the line in &rho;-z; the azimuthal from the orientation of the vertex with respect to the center of the circle fit.
 
@@ -49,7 +51,7 @@ The output of the estimation phase is a set of dataframes saved to parquet files
 - ic_amplitude: the ion chamber charge amplitude for this event
 - ic_centroid: the ion chamber centroid (time) for this event
 - ic_integral: the ion chamber integrated charge for this event
-- ic_multiplicity: the ion chamber peak multiplicity for this event (only relevant for legacy data)
+- ic_multiplicity: the ion chamber peak multiplicity for this event
 - vertex_x: the estimated vertex x-coordinate (mm)
 - vertex_y: the estimated vertex y-coordinate (mm)
 - vertex_z: the estimated vertex z-coordinate (mm)
@@ -63,10 +65,8 @@ The output of the estimation phase is a set of dataframes saved to parquet files
 - dE: the total integrated charge sum over the length of the first arc (arb.)
 - arclength: the length of the first arc (mm)
 - direction: indicates the detected direction of the trajectory (forward or backward)
-- eloss: Summed integrated charge up to some cutoff (arb.) (Experimental, not used)
-- cutoff_index: Index in the cluster up to which the eloss was summed. (Experimental, not used)
 
-Units are given where relevant. Some values are experimental and not meant for use in final analysis.
+Units are given where relevant.
 
 ## Plotting and Particle ID
 

--- a/notebooks/examine_estimates.ipynb
+++ b/notebooks/examine_estimates.ipynb
@@ -47,9 +47,28 @@
     "config = load_config('../local_config.json')\n",
     "ws = Workspace(config.workspace)\n",
     "\n",
-    "results: dict[str, list] = {'event': [], 'cluster_index': [], 'cluster_label': [], 'ic_amplitude': [], 'ic_centroid': [], 'ic_integral': [], 'ic_multiplicity': [], 'vertex_x': [], 'vertex_y': [], 'vertex_z': [],\\\n",
-    "                             'center_x': [], 'center_y': [], 'center_z': [], 'polar': [], 'azimuthal': [],\\\n",
-    "                             'brho': [], 'dEdx': [], 'dE': [], 'arclength': [], 'direction': [], 'eloss': [], 'cutoff_index': []}"
+    "results: dict[str, list] = {\n",
+    "    'event': [], \n",
+    "    'cluster_index': [], \n",
+    "    'cluster_label': [], \n",
+    "    'ic_amplitude': [], \n",
+    "    'ic_centroid': [], \n",
+    "    'ic_integral': [], \n",
+    "    'ic_multiplicity': [], \n",
+    "    'vertex_x': [], \n",
+    "    'vertex_y': [], \n",
+    "    'vertex_z': [],\n",
+    "    'center_x': [], \n",
+    "    'center_y': [], \n",
+    "    'center_z': [], \n",
+    "    'polar': [], \n",
+    "    'azimuthal': [],\n",
+    "    'brho': [], \n",
+    "    'dEdx': [], \n",
+    "    'dE': [], \n",
+    "    'arclength': [], \n",
+    "    'direction': []\n",
+    "}"
    ]
   },
   {
@@ -124,7 +143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can look at some of our results! First we'll look at the circle fit, and the estimated vertex poistion, which is how we estimate $B\\rho$. We'll also draw a line corresponding to the estimated initial direction"
+    "Now we can look at some of our results! First we'll look at the circle fit, and the estimated vertex poistion, which is how we estimate $B\\rho$. We'll also draw a line corresponding to the estimated initial direction. One important part of the estimation phase is smoothing. Smoothing splines are applied to the x, y, and charge coordinates as a function of z. So your cluster might look a little different than before, but that is by design. The smoothing helps us get accurate measures for important quantities like dEdx."
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ numba==0.59.0
 plotly==5.19.0
 scikit-learn==1.4.1.post1
 tqdm==4.66.2
-rocket-fft==0.2.4
+rocket-fft==0.2.5

--- a/spyral/core/cluster.py
+++ b/spyral/core/cluster.py
@@ -3,6 +3,7 @@ from .config import ClusterParameters
 import numpy as np
 from dataclasses import dataclass, field
 from sklearn.neighbors import LocalOutlierFactor
+from scipy.interpolate import BSpline, make_smoothing_spline
 
 
 @dataclass
@@ -62,6 +63,12 @@ class Cluster:
             The label from the clustering algorithm (default = -1)
         data: ndarray
             The PointCloud data for the Cluster (default = empty array)
+        x_spline: BSpline | None
+            An optional spline on z-x to smooth the cluster.
+        y_spline: BSpline | None
+            An optional spline on z-y to smooth the cluster.
+        c_spline: BSpline | None
+            An optional spline on z-charge to smooth the cluster.
 
         Returns
         -------
@@ -71,6 +78,9 @@ class Cluster:
         self.event = event
         self.label = label
         self.data = data
+        self.x_spline: BSpline | None = None
+        self.y_spline: BSpline | None = None
+        self.c_spline: BSpline | None = None
 
     def from_labeled_cloud(self, cloud: LabeledCloud, params: ClusterParameters):
         """Convert a LabeledCloud to a Cluster, dropping any outliers
@@ -122,6 +132,52 @@ class Cluster:
         neigh = LocalOutlierFactor(n_neighbors=neighbors)
         result = neigh.fit_predict(test_data)
         self.data = self.data[result > 0]  # label=-1 is an outlier
+
+    def create_splines(self, smoothing: float = 1.0) -> None:
+        """Create smoothing splines for the x,y,charge dimensions
+
+        Create smoothing splines along the z-coordinate for x, y, and charge.
+        The degree of smoothing is controlled by the smoothing parameter. smoothing = 0.0 is
+        no smoothing (pure interpolation) and higher values gives a higher degree of smoothing.
+
+        Parameters
+        ----------
+        smoothing: float
+            The smoothing factor (lambda in the scipy notation). Must be a positive float or zero.
+        """
+
+        self.x_spline = make_smoothing_spline(
+            self.data[:, 2], self.data[:, 0], lam=smoothing
+        )
+        self.y_spline = make_smoothing_spline(
+            self.data[:, 2], self.data[:, 1], lam=smoothing
+        )
+        self.c_spline = make_smoothing_spline(
+            self.data[:, 2], self.data[:, 3], lam=smoothing
+        )
+
+    def apply_smoothing_splines(self, smoothing: float = 1.0) -> None:
+        """Apply smoothing to the underlying cluster data with smoothing splines
+
+        Apply smoothing splines to the x, y, and charge dimensions as a function of
+        z. The degree of smoothing is controlled by the smoothing parameter. If the splines
+        are not already created using the create_splines function, they will be created here.
+
+        Note: This function modifies the underlying data in the cluster. This is not a reversible operation.
+
+        Parameters
+        ----------
+        smoothing: float
+            The smoothing factor (lambda in the scipy notation). Must be a positive float or zero.
+
+        """
+
+        if self.x_spline is None or self.y_spline is None or self.c_spline is None:
+            self.create_splines(smoothing)
+
+        self.data[:, 0] = self.x_spline(self.data[:, 2])
+        self.data[:, 1] = self.y_spline(self.data[:, 2])
+        self.data[:, 3] = self.c_spline(self.data[:, 2])
 
 
 def convert_labeled_to_cluster(

--- a/spyral/core/config.py
+++ b/spyral/core/config.py
@@ -212,9 +212,13 @@ class EstimateParameters:
     ----------
     min_total_trajectory_points: int
         minimum number of points in a cluster for the cluster to be considered a particle trajectory
+    smoothing_factor: float
+        smoothing factor for creation of smoothing splines. See scipy's documentaion for make_smoothing_splines
+        and in particular the lam parameter for more details.
     """
 
     min_total_trajectory_points: int = 0
+    smoothing_factor: float = 0.0
 
 
 @dataclass
@@ -383,6 +387,7 @@ def deserialize_config(json_data: dict[Any, Any]) -> Config:
     config.estimate.min_total_trajectory_points = est_params[
         "mininum_total_trajectory_points"
     ]
+    config.estimate.smoothing_factor = est_params["smoothing_factor"]
 
     solver_params = json_data["Solver"]
     config.solver.gas_data_path = solver_params["gas_data_path"]

--- a/spyral/core/estimator.py
+++ b/spyral/core/estimator.py
@@ -37,6 +37,30 @@ def estimate_physics(
     detector_params: DetectorParameters,
     results: dict[str, list],
 ):
+    """Entry point for estimation
+
+    This is the parent function for estimation. It handles checking that the data
+    meets the conditions to be estimated, applying splines to data, and
+    esuring that the estimation results pass a sanity check.
+
+    Parameters
+    ----------
+    cluster_index: int
+        The cluster index in the HDF5 file.
+    cluster: Cluster
+        The cluster to estimate
+    ic_amplitude:
+        The ion chamber amplitude for this cluster
+    ic_centroid:
+        The ion chamber centroid for this cluster
+    ic_integral:
+        The ion chamber integral for this cluster
+    detector_params:
+        Configuration parameters for the physical detector properties
+    results: dict[str, int]
+        Dictionary to store estimation results in
+
+    """
     # Check if we have enough points to estimate
     if len(cluster.data) < estimate_params.min_total_trajectory_points:
         return
@@ -55,7 +79,7 @@ def estimate_physics(
         results,
     )
 
-    # If estimation was consistent or didn't meet valid criteria were done
+    # If estimation was consistent or didn't meet valid criteria we're done
     if is_good or (not is_good and direction == Direction.NONE):
         return
     # If we made a bad guess, try the other direction

--- a/spyral/core/estimator.py
+++ b/spyral/core/estimator.py
@@ -37,6 +37,12 @@ def estimate_physics(
     detector_params: DetectorParameters,
     results: dict[str, list],
 ):
+    # Check if we have enough points to estimate
+    if len(cluster.data) < estimate_params.min_total_trajectory_points:
+        return
+    # Generate smoothing splines, these will give us better distance measures
+    cluster.apply_smoothing_splines(1.0)
+
     # Run estimation where we attempt to guess the right direction
     is_good, direction = estimate_physics_pass(
         cluster_index,
@@ -45,7 +51,6 @@ def estimate_physics(
         ic_centroid,
         ic_integral,
         ic_multiplicity,
-        estimate_params,
         detector_params,
         results,
     )
@@ -62,7 +67,6 @@ def estimate_physics(
             ic_centroid,
             ic_integral,
             ic_multiplicity,
-            estimate_params,
             detector_params,
             results,
             Direction.BACKWARD,
@@ -75,15 +79,22 @@ def estimate_physics(
             ic_centroid,
             ic_integral,
             ic_multiplicity,
-            estimate_params,
             detector_params,
             results,
             Direction.FORWARD,
         )
 
 
-def choose_direction(cluster: Cluster) -> Direction:
-    rhos = np.linalg.norm(cluster.data[:, :2], axis=1)  # cylindrical coordinates rho
+def choose_direction(cluster_data: np.ndarray) -> Direction:
+    """Choose a direction for the trajectory based on which end of the data is in-spiraling
+
+    Parameters
+    ----------
+    cluster_data: np.ndarray
+        T
+
+    """
+    rhos = np.linalg.norm(cluster_data[:, :2], axis=1)  # cylindrical coordinates rho
     direction = Direction.NONE
 
     # See if in-spiraling to the window or microgmegas, sets the direction and guess of z-vertex
@@ -102,7 +113,6 @@ def estimate_physics_pass(
     ic_centroid: float,
     ic_integral: float,
     ic_multiplicity: float,
-    estimate_params: EstimateParameters,
     detector_params: DetectorParameters,
     results: dict[str, list],
     chosen_direction: Direction = Direction.NONE,
@@ -124,17 +134,13 @@ def estimate_physics_pass(
         The ion chamber centroid for this cluster
     ic_integral:
         The ion chamber integral for this cluster
-    estimate_params:
-        Configuration parameters controlling the estimation algorithm
     detector_params:
         Configuration parameters for the physical detector properties
     results: dict[str, int]
         Dictionary to store estimation results in
 
     """
-    # Do some cleanup, reject clusters which have too few points
-    if len(cluster.data) < estimate_params.min_total_trajectory_points:
-        return (False, Direction.NONE)
+    # Do some cleanup, reject clusters which have too many beam region points
     beam_region_fraction = float(
         len(
             cluster.data[
@@ -149,40 +155,43 @@ def estimate_physics_pass(
     direction = chosen_direction
     vertex = np.array([0.0, 0.0, 0.0])  # reaction vertex
     center = np.array([0.0, 0.0, 0.0])  # spiral center
+    # copy the data so we can modify it without worrying about side-effects
+    cluster_data = cluster.data.copy()
+
     # If chosen direction is set to NONE, we want to have the algorithm
     # try to decide which direction the trajectory is going
     if direction == Direction.NONE:
-        direction = choose_direction(cluster)
+        direction = choose_direction(cluster_data)
 
     if direction == Direction.BACKWARD:
-        cluster.data = np.flip(cluster.data, axis=0)
+        cluster_data = np.flip(cluster_data, axis=0)
 
     # Guess that the vertex is the first point; make sure to copy! not reference
-    vertex[:] = cluster.data[0, :3]
+    vertex[:] = cluster_data[0, :3]
 
     # Find the first point that is furthest from the vertex in rho (maximum) to get the first arc of the trajectory
-    rho_to_vertex = np.linalg.norm(cluster.data[1:, :2] - vertex[:2], axis=1)
+    rho_to_vertex = np.linalg.norm(cluster_data[1:, :2] - vertex[:2], axis=1)
     maximum = np.argmax(rho_to_vertex)
-    first_arc = cluster.data[: (maximum + 1)]
+    first_arc = cluster_data[: (maximum + 1)]
 
     # Fit a circle to the first arc and extract some physics
     center[0], center[1], radius, _ = least_squares_circle(
         first_arc[:, 0], first_arc[:, 1]
     )
-    # better_radius = np.linalg.norm(cluster.data[0, :2] - center[:2])
+    # radius = np.linalg.norm(cluster_data[0, :2] - center[:2])
     circle = generate_circle_points(center[0], center[1], radius)
     # Re-estimate vertex using the fitted circle. Extrapolate back to point closest to beam axis
     vertex_estimate_index = np.argsort(np.linalg.norm(circle, axis=1))[0]
     vertex[:2] = circle[vertex_estimate_index]
     # Re-calculate distance to vertex, maximum, first arc
-    rho_to_vertex = np.linalg.norm((cluster.data[:, :2] - vertex[:2]), axis=1)
+    rho_to_vertex = np.linalg.norm((cluster_data[:, :2] - vertex[:2]), axis=1)
     maximum = np.argmax(rho_to_vertex)
-    first_arc = cluster.data[: (maximum + 1)]
+    first_arc = cluster_data[: (maximum + 1)]
 
     # Do a linear fit to small segment of trajectory to extract rho vs. z and extrapolate vertex z
     test_index = max(10, int(maximum * 0.5))
     # test_index = 10
-    fit = linregress(cluster.data[:test_index, 2], rho_to_vertex[:test_index])
+    fit = linregress(cluster_data[:test_index, 2], rho_to_vertex[:test_index])
     vertex_rho = np.linalg.norm(vertex[:2])
     vertex[2] = (vertex_rho - fit.intercept) / fit.slope
     center[2] = vertex[2]
@@ -217,33 +226,45 @@ def estimate_physics_pass(
     if np.isnan(brho):
         brho = 0.0
 
-    arclength = 0.0
+    # arclength = 0.0
     charge_deposited = first_arc[0, 3]
+    small_pad_cutoff = -1  # Where do we cross from big pads to small pads
     for idx in range(len(first_arc) - 1):
         # Stop integrating if we leave the small pad region
         if np.linalg.norm(first_arc[idx + 1, :2]) > 152.0:
+            small_pad_cutoff = idx + 1
             break
-        arclength += np.linalg.norm(first_arc[idx + 1, :3] - first_arc[idx, :3])
+        # arclength += np.linalg.norm(first_arc[idx + 1, :3] - first_arc[idx, :3])
         charge_deposited += first_arc[idx + 1, 3]
-    if arclength == 0.0:
+    if charge_deposited == first_arc[0, 3]:
         return (False, Direction.NONE)
+
+    # Use the splines to do a fine-grained line integral to calculate the distance
+    points = np.empty((1000, 3))
+    points[:, 2] = np.linspace(first_arc[0, 2], first_arc[small_pad_cutoff, 2], 1000)
+    points[:, 0] = cluster.x_spline(points[:, 2])
+    points[:, 1] = cluster.y_spline(points[:, 2])
+    arclength = np.sqrt((np.diff(points, axis=0) ** 2.0).sum(axis=1)).sum()  # integrate
+
     dEdx = charge_deposited / arclength
 
-    integral_len = np.linalg.norm(cluster.data[0, :3] - vertex)
-    eloss = cluster.data[0, 3]
-    cutoff = 700.0  # mm
-    index = 1
-    while True:
-        if index == len(cluster.data):
-            break
-        elif integral_len > cutoff:
-            break
-        eloss += cluster.data[index, 3]
-        integral_len += np.linalg.norm(
-            cluster.data[index, :3] - cluster.data[index - 1, :3]
-        )
-        index += 1
-    cutoff_index = index
+    # GWM: Needs removing but do it carefully
+    # integral_len = np.linalg.norm(cluster_data[0, :3] - vertex)
+    # eloss = cluster_data[0, 3]
+    # cutoff = 700.0  # mm
+    # index = 1
+    # while True:
+    #     if index == len(cluster_data):
+    #         break
+    #     elif integral_len > cutoff:
+    #         break
+    #     eloss += cluster_data[index, 3]
+    #     integral_len += np.linalg.norm(
+    #         cluster_data[index, :3] - cluster_data[index - 1, :3]
+    #     )
+    #     index += 1
+    # cutoff_index = index
+
     # fill in our map
     results["event"].append(cluster.event)
     results["cluster_index"].append(cluster_index)
@@ -265,6 +286,6 @@ def estimate_physics_pass(
     results["dE"].append(charge_deposited)
     results["arclength"].append(arclength)
     results["direction"].append(direction.value)
-    results["eloss"].append(eloss)
-    results["cutoff_index"].append(cutoff_index)
+    results["eloss"].append(-1.0)
+    results["cutoff_index"].append(-1)
     return (True, direction)

--- a/spyral/core/estimator.py
+++ b/spyral/core/estimator.py
@@ -41,7 +41,7 @@ def estimate_physics(
     if len(cluster.data) < estimate_params.min_total_trajectory_points:
         return
     # Generate smoothing splines, these will give us better distance measures
-    cluster.apply_smoothing_splines(1.0)
+    cluster.apply_smoothing_splines(estimate_params.smoothing_factor)
 
     # Run estimation where we attempt to guess the right direction
     is_good, direction = estimate_physics_pass(
@@ -247,23 +247,6 @@ def estimate_physics_pass(
     arclength = np.sqrt((np.diff(points, axis=0) ** 2.0).sum(axis=1)).sum()  # integrate
 
     dEdx = charge_deposited / arclength
-
-    # GWM: Needs removing but do it carefully
-    # integral_len = np.linalg.norm(cluster_data[0, :3] - vertex)
-    # eloss = cluster_data[0, 3]
-    # cutoff = 700.0  # mm
-    # index = 1
-    # while True:
-    #     if index == len(cluster_data):
-    #         break
-    #     elif integral_len > cutoff:
-    #         break
-    #     eloss += cluster_data[index, 3]
-    #     integral_len += np.linalg.norm(
-    #         cluster_data[index, :3] - cluster_data[index - 1, :3]
-    #     )
-    #     index += 1
-    # cutoff_index = index
 
     # fill in our map
     results["event"].append(cluster.event)

--- a/spyral/core/estimator.py
+++ b/spyral/core/estimator.py
@@ -286,6 +286,4 @@ def estimate_physics_pass(
     results["dE"].append(charge_deposited)
     results["arclength"].append(arclength)
     results["direction"].append(direction.value)
-    results["eloss"].append(-1.0)
-    results["cutoff_index"].append(-1)
     return (True, direction)

--- a/spyral/core/pad_map.py
+++ b/spyral/core/pad_map.py
@@ -3,6 +3,8 @@ from .hardware_id import HardwareID, generate_electronics_id
 from pathlib import Path
 from dataclasses import dataclass, field
 
+from .legacy_beam_pads import LEGACY_BEAM_PADS
+
 
 @dataclass
 class PadData:
@@ -86,11 +88,6 @@ class PadMap:
         """
         self.map: dict[int, PadData] = {}
         self.elec_map: dict[int, int] = {}
-        self.beam_pads: list[int] = []
-        if is_legacy:
-            from .legacy_beam_pads import LEGACY_BEAM_PADS
-
-            self.beam_pads = LEGACY_BEAM_PADS
         self.load(
             geometry_path, gain_path, time_correction_path, electronics_path, scale_path
         )
@@ -203,4 +200,4 @@ class PadMap:
         return None
 
     def is_beam_pad(self, pad_id: int) -> bool:
-        return pad_id in self.beam_pads
+        return pad_id in LEGACY_BEAM_PADS

--- a/spyral/phase_estimate.py
+++ b/spyral/phase_estimate.py
@@ -81,8 +81,6 @@ def phase_estimate(
         "dE": [],
         "arclength": [],
         "direction": [],
-        "eloss": [],
-        "cutoff_index": [],
     }
 
     # Process data
@@ -99,10 +97,10 @@ def phase_estimate(
             continue
 
         nclusters = event.attrs["nclusters"]
-        ic_amp: float = event.attrs["ic_amplitude"]
-        ic_cent: float = event.attrs["ic_centroid"]
-        ic_int: float = event.attrs["ic_integral"]
-        ic_mult: float = event.attrs["ic_multiplicity"]
+        ic_amp = float(event.attrs["ic_amplitude"])
+        ic_cent = float(event.attrs["ic_centroid"])
+        ic_int = float(event.attrs["ic_integral"])
+        ic_mult = float(event.attrs["ic_multiplicity"])
         # Go through every cluster in each event
         for cidx in range(0, nclusters):
             local_cluster: h5.Group | None = None

--- a/spyral/phase_solve.py
+++ b/spyral/phase_solve.py
@@ -115,7 +115,7 @@ def phase_solve(
     flush_val = int(flush_percent * (len(estimates_gated["event"])))
     count = 0
     if len(estimates_gated["event"]) < 100:
-        flush_percent = 100.0 / float(len(estimates_gated["event"]))
+        flush_percent = 1.0 / float(len(estimates_gated["event"]))
         flush_val = 1
         count = 0
 


### PR DESCRIPTION
Add smoothing splines to estimation phase to improve line integral related estimates (dEdx in particular). This shows good improvement in the particle ID spectrum.