### PR TITLE
Fix SharedMemory Windows Bug, turn off allow_single_cluster

### DIFF
--- a/src/spyral/core/clusterize.py
+++ b/src/spyral/core/clusterize.py
@@ -280,7 +280,6 @@ def form_clusters(
     clusterizer = skcluster.HDBSCAN(  # type: ignore
         min_cluster_size=min_size,
         min_samples=params.min_points,
-        allow_single_cluster=True,
         cluster_selection_epsilon=epsilon,
     )
 

--- a/src/spyral/core/pipeline.py
+++ b/src/spyral/core/pipeline.py
@@ -250,7 +250,7 @@ def start_pipeline(
     """
     # Setup
     # Note the manager exists outside the pipeline
-    shared_manager = SharedMemoryManager(("", 50000))
+    shared_manager = SharedMemoryManager()
     shared_manager.start()
 
     print(SPLASH)


### PR DESCRIPTION
Address issue #153 

allow_single_cluster seems to cause issues on noisy events with single clusters. Counterintuitively, this seems to make those events harder to treat.