### PR TITLE
Dependency compat with Polaris

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attpc_spyral"
-version = "0.14.0rc1"
+version = "0.14.0rc2"
 description = "AT-TPC analysis pipeline"
 authors = [
     {name = "gwm17", email = "gordonmccann215@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ dependencies = [
     "lmfit>=1.3.0",
     "numba>=0.59.1",
     "scikit-learn>=1.4.2",
-    "tqdm>=4.66.2",
+    "tqdm>=4.65.0",
     "rocket-fft>=0.2.5",
     "typing-extensions>=4.11.0",
-    "psutil>=6.0.0",
+    "psutil>=5.9.8",
     "python-dotenv>=1.0.1",
 ]
 requires-python = ">=3.10,<3.13"


### PR DESCRIPTION
Downgrade the minimum version for a few deps (psutil, tqdm) to avoid conflicts with the Polaris base.