### PR TITLE
Fix self generated IC scaler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attpc_spyral"
-version = "0.14.0rc2"
+version = "0.14.0rc3"
 description = "AT-TPC analysis pipeline"
 authors = [
     {name = "gwm17", email = "gordonmccann215@gmail.com"},

--- a/src/spyral/phases/pointcloud_phase.py
+++ b/src/spyral/phases/pointcloud_phase.py
@@ -15,6 +15,7 @@ from ..correction import (
 )
 from ..core.spy_log import spyral_warn, spyral_info
 from ..trace.trace_reader import TraceReader
+from ..trace.frib_event import TriggerType
 from ..trace.peak import Peak
 from ..core.pad_map import PadMap
 from ..core.point_cloud import PointCloud
@@ -184,7 +185,10 @@ class PointcloudPhase(PhaseLike):
             event = trace_reader.read_event(idx, self.get_params, self.frib_params, rng)
             ic_mult = -1.0
             ic_peak: None | Peak = None
-            if event.frib is not None:
+            if (
+                event.frib is not None
+                and event.frib.trigger == TriggerType.IC_DOWNSCALE_TRIGGER
+            ):
                 ic_mult = event.frib.get_ic_multiplicity(self.frib_params)
                 ic_peak = event.frib.get_triggering_ic_peak(self.frib_params)
                 if (
@@ -193,6 +197,7 @@ class PointcloudPhase(PhaseLike):
                     and ic_peak is not None
                 ):  # ugh
                     ic_within_mult_count += 1
+                continue
             if event.get is None:
                 continue
 

--- a/src/spyral/trace/trace_reader.py
+++ b/src/spyral/trace/trace_reader.py
@@ -206,14 +206,16 @@ class TraceReader:
         frib_evt_group: h5.Group = self.file["frib"]["evt"]  # type: ignore
         event_name = f"evt{event_id}_data"
         frib_event_name = f"evt{event_id}_1903"
+        frib_coinc_name = f"evt{event_id}_977"
 
         event = Event(event_id, None, None)
         if event_name in get_group:
             get_data: h5.Dataset = get_group[event_name]  # type: ignore
             event.get = GetEvent(get_data[:], event_id, get_params, rng)
-        if frib_event_name in frib_evt_group:
+        if frib_event_name in frib_evt_group and frib_coinc_name in frib_evt_group:
             frib_data: h5.Dataset = frib_evt_group[frib_event_name]  # type: ignore
-            event.frib = FribEvent(frib_data[:], event_id, frib_params)
+            frib_coinc: h5.Dataset = frib_evt_group[frib_coinc_name]  # type: ignore
+            event.frib = FribEvent(frib_data[:], frib_coinc[:], event_id, frib_params)
         return event
 
     def read_event_merger_current(
@@ -251,7 +253,10 @@ class TraceReader:
             event.get = GetEvent(get_data[:], event_id, get_params, rng)
             if "frib_physics" in event_data:
                 frib_1903_data: h5.Dataset = events_group["frib_physics"]["1903"]  # type: ignore
-                event.frib = FribEvent(frib_1903_data[:], event_id, frib_params)
+                frib_977_data: h5.Dataset = events_group["frib_physics"]["977"]  # type: ignore
+                event.frib = FribEvent(
+                    frib_1903_data[:], frib_977_data[:], event_id, frib_params
+                )
         return event
 
     def read_scalers(self) -> FribScalers | None:


### PR DESCRIPTION
Fix self generated IC scaler by properly implementing the trigger check within the FRIBDAQ data and removing the downscale beam events from the analysis. Add TriggerType to identify the type of trigger for this event.