### PR TITLE
Add Harmonizer compat, Fix bug in InterpSolver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attpc_spyral"
-version = "0.14.0"
+version = "0.15.0rc0"
 description = "AT-TPC analysis pipeline"
 authors = [
     {name = "gwm17", email = "gordonmccann215@gmail.com"},

--- a/src/spyral/core/estimator.py
+++ b/src/spyral/core/estimator.py
@@ -34,6 +34,8 @@ def estimate_physics(
     ic_centroid: float,
     ic_integral: float,
     ic_multiplicity: float,
+    orig_run: int,
+    orig_event: int,
     estimate_params: EstimateParameters,
     detector_params: DetectorParameters,
     results: dict[str, list],
@@ -56,6 +58,10 @@ def estimate_physics(
         The ion chamber centroid for this cluster
     ic_integral:
         The ion chamber integral for this cluster
+    orig_run:
+        The original event run number
+    orig_event:
+        The original event number
     detector_params:
         Configuration parameters for the physical detector properties
     results: dict[str, int]
@@ -87,6 +93,8 @@ def estimate_physics(
         ic_centroid,
         ic_integral,
         ic_multiplicity,
+        orig_run,
+        orig_event,
         detector_params,
         results,
     )
@@ -103,6 +111,8 @@ def estimate_physics(
             ic_centroid,
             ic_integral,
             ic_multiplicity,
+            orig_run,
+            orig_event,
             detector_params,
             results,
             Direction.BACKWARD,
@@ -115,6 +125,8 @@ def estimate_physics(
             ic_centroid,
             ic_integral,
             ic_multiplicity,
+            orig_run,
+            orig_event,
             detector_params,
             results,
             Direction.FORWARD,
@@ -149,6 +161,8 @@ def estimate_physics_pass(
     ic_centroid: float,
     ic_integral: float,
     ic_multiplicity: float,
+    orig_run: int,
+    orig_event: int,
     detector_params: DetectorParameters,
     results: dict[str, list],
     chosen_direction: Direction = Direction.NONE,
@@ -164,13 +178,19 @@ def estimate_physics_pass(
         The cluster index in the HDF5 file.
     cluster: Cluster
         The cluster to estimate
-    ic_amplitude:
+    ic_amplitude: float
         The ion chamber amplitude for this cluster
-    ic_centroid:
+    ic_centroid: float
         The ion chamber centroid for this cluster
-    ic_integral:
+    ic_integral: float
         The ion chamber integral for this cluster
-    detector_params:
+    ic_multiplicity: float
+        The ion chamber multiplicity for this cluster
+    orig_run: int
+        The original run number
+    orig_event: int
+        The original event number
+    detector_params: DetectorParameters
         Configuration parameters for the physical detector properties
     results: dict[str, int]
         Dictionary to store estimation results in
@@ -284,6 +304,8 @@ def estimate_physics_pass(
     results["event"].append(cluster.event)
     results["cluster_index"].append(cluster_index)
     results["cluster_label"].append(cluster.label)
+    results["orig_run"].append(orig_run)
+    results["orig_event"].append(orig_event)
     results["ic_amplitude"].append(ic_amplitude)
     results["ic_centroid"].append(ic_centroid)
     results["ic_integral"].append(ic_integral)

--- a/src/spyral/phases/cluster_phase.py
+++ b/src/spyral/phases/cluster_phase.py
@@ -146,6 +146,8 @@ class ClusterPhase(PhaseLike):
             # Each event can contain many clusters
             cluster_event_group = cluster_group.create_group(f"event_{idx}")
             cluster_event_group.attrs["nclusters"] = len(cleaned)
+            cluster_event_group.attrs["orig_run"] = cloud_data.attrs["orig_run"]
+            cluster_event_group.attrs["orig_event"] = cloud_data.attrs["orig_event"]
             cluster_event_group.attrs["ic_amplitude"] = cloud_data.attrs["ic_amplitude"]
             cluster_event_group.attrs["ic_centroid"] = cloud_data.attrs["ic_centroid"]
             cluster_event_group.attrs["ic_integral"] = cloud_data.attrs["ic_integral"]

--- a/src/spyral/phases/estimation_phase.py
+++ b/src/spyral/phases/estimation_phase.py
@@ -114,6 +114,8 @@ class EstimationPhase(PhaseLike):
             "event": [],
             "cluster_index": [],
             "cluster_label": [],
+            "orig_run": [],
+            "orig_event": [],
             "ic_amplitude": [],
             "ic_centroid": [],
             "ic_integral": [],
@@ -156,6 +158,8 @@ class EstimationPhase(PhaseLike):
             ic_cent = float(event.attrs["ic_centroid"])  # type: ignore
             ic_int = float(event.attrs["ic_integral"])  # type: ignore
             ic_mult = float(event.attrs["ic_multiplicity"])  # type: ignore
+            orig_run = int(event.attrs["orig_run"])  # type: ignore
+            orig_event = int(event.attrs["orig_event"])  # type: ignore
             # Go through every cluster in each event
             for cidx in range(0, nclusters):
                 local_cluster: h5.Group | None = None
@@ -179,6 +183,8 @@ class EstimationPhase(PhaseLike):
                     ic_cent,
                     ic_int,
                     ic_mult,
+                    orig_run,
+                    orig_event,
                     self.estimate_params,
                     self.det_params,
                     data,

--- a/src/spyral/phases/interp_leastsq_solver_phase.py
+++ b/src/spyral/phases/interp_leastsq_solver_phase.py
@@ -281,6 +281,8 @@ class InterpLeastSqSolverPhase(PhaseLike):
             "event": [],
             "cluster_index": [],
             "cluster_label": [],
+            "orig_run": [],
+            "orig_event": [],
             "vertex_x": [],
             "sigma_vx": [],
             "vertex_y": [],
@@ -329,6 +331,8 @@ class InterpLeastSqSolverPhase(PhaseLike):
                 local_cluster.attrs["label"],  # type: ignore
                 local_cluster["cloud"][:].copy(),  # type: ignore
             )
+            orig_run = estimates_gated["orig_run"][row]
+            orig_event = estimates_gated["orig_event"][row]
 
             # Do the solver
             guess = Guess(
@@ -342,6 +346,8 @@ class InterpLeastSqSolverPhase(PhaseLike):
             )
             solve_physics_interp(
                 cidx,
+                orig_run,
+                orig_event,
                 cluster,
                 guess,
                 pid.nucleus,

--- a/src/spyral/phases/interp_solver_phase.py
+++ b/src/spyral/phases/interp_solver_phase.py
@@ -213,7 +213,7 @@ class InterpSolverPhase(PhaseLike):
 
         # Check the cluster phase and estimate phase data
         cluster_path: Path = payload.artifacts["cluster"]
-        estimate_path = payload.artifacts["estimate"]
+        estimate_path = payload.artifacts["estimation"]
         if not cluster_path.exists() or not estimate_path.exists():
             msg_queue.put(StatusMessage("Waiting", 0, 0, payload.run_number))
             spyral_warn(

--- a/src/spyral/phases/interp_solver_phase.py
+++ b/src/spyral/phases/interp_solver_phase.py
@@ -281,6 +281,8 @@ class InterpSolverPhase(PhaseLike):
             "event": [],
             "cluster_index": [],
             "cluster_label": [],
+            "orig_run": [],
+            "orig_event": [],
             "vertex_x": [],
             "sigma_vx": [],
             "vertex_y": [],
@@ -329,6 +331,8 @@ class InterpSolverPhase(PhaseLike):
                 local_cluster.attrs["label"],  # type: ignore
                 local_cluster["cloud"][:].copy(),  # type: ignore
             )
+            orig_run = estimates_gated["orig_run"][row]
+            orig_event = estimates_gated["orig_event"][row]
 
             # Do the solver
             guess = Guess(
@@ -342,6 +346,8 @@ class InterpSolverPhase(PhaseLike):
             )
             solve_physics_interp(
                 cidx,
+                orig_run,
+                orig_event,
                 cluster,
                 guess,
                 pid.nucleus,

--- a/src/spyral/phases/pointcloud_phase.py
+++ b/src/spyral/phases/pointcloud_phase.py
@@ -144,7 +144,7 @@ class PointcloudPhase(PhaseLike):
 
         # Open files
         result = self.construct_artifact(payload, workspace_path)
-        trace_reader = TraceReader(trace_path)
+        trace_reader = TraceReader(trace_path, payload.run_number)
         point_file = h5.File(result.artifacts["pointcloud"], "w")
 
         # Load electric field correction
@@ -213,7 +213,9 @@ class PointcloudPhase(PhaseLike):
             pc_dataset = cloud_group.create_dataset(
                 f"cloud_{pc.event_number}", shape=pc.cloud.shape, dtype=np.float64
             )
-
+            # Store original run and event info
+            pc_dataset.attrs["orig_run"] = event.original_run
+            pc_dataset.attrs["orig_event"] = event.original_event
             # default IC settings
             pc_dataset.attrs["ic_amplitude"] = -1.0
             pc_dataset.attrs["ic_integral"] = -1.0
@@ -242,7 +244,7 @@ class PointcloudPhase(PhaseLike):
                 self.get_artifact_path(workspace_path)
                 / f"{form_run_string(payload.run_number)}_scaler.parquet"
             )
-        else:
+        elif trace_reader.should_have_scalers():
             spyral_warn(
                 __name__, f"Run {payload.run_number} does not have scaler data!"
             )

--- a/src/spyral/solvers/solver_interp.py
+++ b/src/spyral/solvers/solver_interp.py
@@ -293,6 +293,8 @@ def fit_model_interp(
 
 def solve_physics_interp(
     cluster_index: int,
+    orig_run: int,
+    orig_event: int,
     cluster: Cluster,
     guess: Guess,
     ejectile: NucleusData,
@@ -309,6 +311,10 @@ def solve_physics_interp(
     ----------
     cluster_index: int
         Index of the cluster in the hdf5 scheme. Used only for debugging
+    orig_run: int
+        The original run number
+    orig_event: int
+        The original event number
     cluster: Cluster
         the data to be fit
     guess: Guess
@@ -360,6 +366,8 @@ def solve_physics_interp(
     results["event"].append(cluster.event)
     results["cluster_index"].append(cluster_index)
     results["cluster_label"].append(cluster.label)
+    results["orig_run"].append(orig_run)
+    results["orig_event"].append(orig_event)
     # Best fit values and uncertainties
     results["vertex_x"].append(best_fit.params["vertex_x"].value)  # type: ignore
     results["vertex_y"].append(best_fit.params["vertex_y"].value)  # type: ignore

--- a/src/spyral/solvers/solver_interp_leastsq.py
+++ b/src/spyral/solvers/solver_interp_leastsq.py
@@ -293,6 +293,8 @@ def fit_model_interp(
 
 def solve_physics_interp(
     cluster_index: int,
+    orig_run: int,
+    orig_event: int,
     cluster: Cluster,
     guess: Guess,
     ejectile: NucleusData,
@@ -309,6 +311,10 @@ def solve_physics_interp(
     ----------
     cluster_index: int
         Index of the cluster in the hdf5 scheme. Used only for debugging
+    orig_run: int
+        The original run number
+    orig_event: int
+        The original event number
     cluster: Cluster
         the data to be fit
     guess: Guess
@@ -362,6 +368,8 @@ def solve_physics_interp(
     results["event"].append(cluster.event)
     results["cluster_index"].append(cluster_index)
     results["cluster_label"].append(cluster.label)
+    results["orig_run"].append(orig_run)
+    results["orig_event"].append(orig_event)
     # Best fit values and uncertainties
     results["vertex_x"].append(best_fit.params["vertex_x"].value)  # type: ignore
     results["vertex_y"].append(best_fit.params["vertex_y"].value)  # type: ignore

--- a/src/spyral/trace/trace_reader.py
+++ b/src/spyral/trace/trace_reader.py
@@ -128,6 +128,8 @@ class TraceReader:
         Read a specific event
     read_scalers()
         Read the scalers
+    should_have_scalers()
+        See if the trace file should have scalers
     """
 
     def __init__(self, path: Path, run_number: int):
@@ -345,7 +347,7 @@ class TraceReader:
         return event
 
     def read_scalers(self) -> FribScalers | None:
-        """Read the scalers scalers
+        """Read the scalers
 
         Returns
         -------
@@ -365,7 +367,7 @@ class TraceReader:
                 )
 
     def read_scalers_merger_020(self) -> FribScalers | None:
-        """Read the scalers scalers for trace version MERGER_020
+        """Read the scalers for trace version MERGER_020
 
         Returns
         -------
@@ -387,7 +389,7 @@ class TraceReader:
         return scalers
 
     def read_scalers_merger_010(self) -> FribScalers | None:
-        """Read the scalers scalers for trace version MERGER_010
+        """Read the scalers for trace version MERGER_010
 
         Returns
         -------
@@ -416,3 +418,14 @@ class TraceReader:
             event += 1
 
         return scalers
+
+    def should_have_scalers(self) -> bool:
+        """Returns True if the file should have scalers
+
+        Returns
+        -------
+        bool
+            True if the file should have scalers (i.e. not harmonizer)
+        """
+
+        return self.version != TraceVersion.HARMONIZER_010

--- a/src/spyral/trace/trace_reader.py
+++ b/src/spyral/trace/trace_reader.py
@@ -30,8 +30,31 @@ class TraceVersion(Enum):
     """
 
     MERGER_010 = 1
-    MERGER_CURRENT = 2
+    MERGER_020 = 2
+    HARMONIZER_010 = 3
     INVALID = -1
+
+
+def version_string_to_enum(version: str) -> TraceVersion:
+    """Converts a version string to a TraceVersion
+
+    Parameters
+    ----------
+    version: str
+        The version string
+
+    Returns
+    -------
+    TraceVersion:
+        The version enum
+    """
+
+    if version == "libattpc_merger:0.2.0":
+        return TraceVersion.MERGER_020
+    elif version == "harmonizer:0.1.0":
+        return TraceVersion.HARMONIZER_010
+    else:
+        return TraceVersion.INVALID
 
 
 @dataclass
@@ -46,11 +69,21 @@ class Event:
         Optional GET trace data
     frib: FribEvent | None
         Optional FRIBDAQ trace data
+    original_run: int
+        The original run number. In the case of merger data
+        this is the same as the current run. In the case of harmonizer
+        data this is the run number before harmonization.
+    original_event: int
+        The original event number. In the case of merger data
+        this is the same as the current event. In the case of harmonizer
+        data this is the event number before harmonization.
     """
 
     id: int
     get: GetEvent | None
     frib: FribEvent | None
+    original_run: int
+    original_event: int
 
 
 class TraceReader:
@@ -73,6 +106,8 @@ class TraceReader:
         The HDF5 file handle
     version: TraceVersion
         The trace format version
+    run_number: int
+        The current run number
     min_event: int
         The first event number
     max_event: int
@@ -82,6 +117,8 @@ class TraceReader:
     ----------
     path: Path
         The path to the trace file
+    run_number: int
+        The trace run number
 
     Methods
     -------
@@ -93,10 +130,11 @@ class TraceReader:
         Read the scalers
     """
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path, run_number: int):
         self.file_path = path
         self.file = h5.File(self.file_path, "r")
         self.version = TraceVersion.INVALID
+        self.run_number: int = run_number
         self.min_event: int = -1
         self.max_event: int = -1
         self.detect_version_and_init()
@@ -111,7 +149,7 @@ class TraceReader:
             self.version = TraceVersion.MERGER_010
             self.init_merger_010()
         elif "events" in self.file.keys():
-            self.version = TraceVersion.MERGER_CURRENT
+            self.version = version_string_to_enum(self.file["events"].attrs["version"])  # type: ignore
             self.init_merger_current()
         else:
             self.version = TraceVersion.INVALID
@@ -168,8 +206,12 @@ class TraceReader:
                 return self.read_event_merger_010(
                     event_id, get_params, frib_params, rng
                 )
-            case TraceVersion.MERGER_CURRENT:
-                return self.read_event_merger_current(
+            case TraceVersion.MERGER_020:
+                return self.read_event_merger_020(
+                    event_id, get_params, frib_params, rng
+                )
+            case TraceVersion.HARMONIZER_010:
+                return self.read_event_harmonizer_010(
                     event_id, get_params, frib_params, rng
                 )
             case _:
@@ -208,7 +250,7 @@ class TraceReader:
         frib_event_name = f"evt{event_id}_1903"
         frib_coinc_name = f"evt{event_id}_977"
 
-        event = Event(event_id, None, None)
+        event = Event(event_id, None, None, self.run_number, event_id)
         if event_name in get_group:
             get_data: h5.Dataset = get_group[event_name]  # type: ignore
             event.get = GetEvent(get_data[:], event_id, get_params, rng)
@@ -218,14 +260,14 @@ class TraceReader:
             event.frib = FribEvent(frib_data[:], frib_coinc[:], event_id, frib_params)
         return event
 
-    def read_event_merger_current(
+    def read_event_merger_020(
         self,
         event_id: int,
         get_params: GetParameters,
         frib_params: FribParameters,
         rng: Generator,
     ) -> Event:
-        """Read a specific event for trace version MERGER_CURRENT
+        """Read a specific event for trace version MERGER_020
 
         Parameters
         ----------
@@ -246,10 +288,53 @@ class TraceReader:
         events_group: h5.Group = self.file["events"]  # type: ignore
         event_name = f"event_{event_id}"
 
-        event = Event(event_id, None, None)
-        if event_id in events_group:
+        event = Event(event_id, None, None, self.run_number, event_id)
+        if event_name in events_group:
             event_data: h5.Group = events_group[event_name]  # type: ignore
-            get_data: h5.Dataset = event_data["event"]  # type: ignore
+            get_data: h5.Dataset = event_data["get_traces"]  # type: ignore
+            event.get = GetEvent(get_data[:], event_id, get_params, rng)
+            if "frib_physics" in event_data:
+                frib_1903_data: h5.Dataset = events_group["frib_physics"]["1903"]  # type: ignore
+                frib_977_data: h5.Dataset = events_group["frib_physics"]["977"]  # type: ignore
+                event.frib = FribEvent(
+                    frib_1903_data[:], frib_977_data[:], event_id, frib_params
+                )
+        return event
+
+    def read_event_harmonizer_010(
+        self,
+        event_id: int,
+        get_params: GetParameters,
+        frib_params: FribParameters,
+        rng: Generator,
+    ) -> Event:
+        """Read a specific event for trace version HARMONIZER_010
+
+        Parameters
+        ----------
+        event_id: int
+            The event to be read
+        get_params: GetParameters
+            Parameters controlling the GET trace analysis
+        frib_params: FribParameters
+            Parameters controlling the FRIBDAQ trace analysis
+        rng: numpy.random.Generator
+            numpy random number generator
+
+        Returns
+        -------
+        Event
+            The event data
+        """
+        events_group: h5.Group = self.file["events"]  # type: ignore
+        event_name = f"event_{event_id}"
+
+        event = Event(event_id, None, None, -1, -1)
+        if event_name in events_group:
+            event_data: h5.Group = events_group[event_name]  # type: ignore
+            event.original_event = event_data.attrs["orig_event"]  # type: ignore
+            event.original_run = event_data.attrs["orig_run"]  # type: ignore
+            get_data: h5.Dataset = event_data["get_traces"]  # type: ignore
             event.get = GetEvent(get_data[:], event_id, get_params, rng)
             if "frib_physics" in event_data:
                 frib_1903_data: h5.Dataset = events_group["frib_physics"]["1903"]  # type: ignore
@@ -270,15 +355,17 @@ class TraceReader:
         match self.version:
             case TraceVersion.MERGER_010:
                 return self.read_scalers_merger_010()
-            case TraceVersion.MERGER_CURRENT:
-                return self.read_scalers_merger_current()
+            case TraceVersion.MERGER_020:
+                return self.read_scalers_merger_020()
+            case TraceVersion.HARMONIZER_010:
+                return None
             case _:
                 raise TraceReaderError(
                     f"Cannot read scalers from trace file {self.file_path}, merger version not supported!"
                 )
 
-    def read_scalers_merger_current(self) -> FribScalers | None:
-        """Read the scalers scalers for trace version MERGER_CURRENT
+    def read_scalers_merger_020(self) -> FribScalers | None:
+        """Read the scalers scalers for trace version MERGER_020
 
         Returns
         -------


### PR DESCRIPTION
Now can accept data from the harmonizer. Original run number and original event number are propagated through the analysis pipeline. InterpSolverPhase had a crashing typo, which is now fixed.